### PR TITLE
Rename requirement.txt to requirements.txt

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -1,1 +1,0 @@
-pytest-playwright

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pytest-playwright


### PR DESCRIPTION
The file name is unrecognised when the pre-checks does a pip install command